### PR TITLE
feat: Add session-level timeout support to BaseSession

### DIFF
--- a/src/requestspro/sessions.py
+++ b/src/requestspro/sessions.py
@@ -10,8 +10,17 @@ from requestspro.auth import RecoverableAuth
 class BaseSession(Session):
     """A base class for requests.Session that accepts kwargs to ease complex inheritance hierarchies."""
 
-    def __init__(self, **kwargs):
+    TIMEOUT = None
+
+    def __init__(self, timeout=None, **kwargs):
         super().__init__()
+        self.timeout = timeout if timeout is not None else self.TIMEOUT
+
+    def request(self, method, url, **kwargs):
+        """Override request to handle session-level timeout."""
+        if 'timeout' not in kwargs and self.timeout is not None:
+            kwargs['timeout'] = self.timeout
+        return super().request(method, url, **kwargs)
 
 
 class BaseUrlSession(BaseSession):

--- a/tests/test_session_timeout.py
+++ b/tests/test_session_timeout.py
@@ -1,35 +1,8 @@
 import pytest
+from unittest.mock import MagicMock
 from requests import Response
-from requests.adapters import HTTPAdapter
+from requests.adapters import BaseAdapter
 from requestspro.sessions import BaseSession
-
-
-class MockAdapter(HTTPAdapter):
-    """Mock adapter that captures send method calls and returns mock responses."""
-    
-    def __init__(self):
-        super().__init__()
-        self.captured_calls = []
-        
-    def send(self, request, stream=False, timeout=None, verify=None, cert=None, proxies=None):
-        """Capture the call parameters and return a mock response."""
-        self.captured_calls.append({
-            'request': request,
-            'timeout': timeout,
-            'stream': stream,
-            'verify': verify,
-            'cert': cert,
-            'proxies': proxies
-        })
-        
-        # Create a mock response
-        response = Response()
-        response.status_code = 200
-        response.headers['Content-Type'] = 'application/json'
-        response._content = b'{"key": "value"}'
-        response.url = request.url
-        response.request = request
-        return response
 
 
 class TestBaseSessionTimeout:
@@ -66,16 +39,21 @@ class TestBaseSessionTimeout:
         session = BaseSession(timeout=5.0)
         
         # Create mock adapter and mount it
-        mock_adapter = MockAdapter()
+        mock_adapter = MagicMock(spec=BaseAdapter)
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.headers['Content-Type'] = 'application/json'
+        mock_response._content = b'{"key": "value"}'
+        mock_adapter.send.return_value = mock_response
         session.mount('http://', mock_adapter)
-        session.mount('https://', mock_adapter)
         
         # Make request
         response = session.request('GET', 'http://example.com')
         
         # Verify timeout was passed to send method
-        assert len(mock_adapter.captured_calls) == 1
-        assert mock_adapter.captured_calls[0]['timeout'] == 5.0
+        mock_adapter.send.assert_called_once()
+        args, kwargs = mock_adapter.send.call_args
+        assert kwargs['timeout'] == 5.0
         assert response.status_code == 200
 
     def test_per_request_timeout_overrides_session_timeout(self):
@@ -83,16 +61,21 @@ class TestBaseSessionTimeout:
         session = BaseSession(timeout=5.0)
         
         # Create mock adapter and mount it
-        mock_adapter = MockAdapter()
+        mock_adapter = MagicMock(spec=BaseAdapter)
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.headers['Content-Type'] = 'application/json'
+        mock_response._content = b'{"key": "value"}'
+        mock_adapter.send.return_value = mock_response
         session.mount('http://', mock_adapter)
-        session.mount('https://', mock_adapter)
         
         # Make request with per-request timeout
         response = session.request('GET', 'http://example.com', timeout=10.0)
         
         # Verify per-request timeout was used
-        assert len(mock_adapter.captured_calls) == 1
-        assert mock_adapter.captured_calls[0]['timeout'] == 10.0
+        mock_adapter.send.assert_called_once()
+        args, kwargs = mock_adapter.send.call_args
+        assert kwargs['timeout'] == 10.0
         assert response.status_code == 200
 
     def test_no_session_timeout_no_per_request_timeout(self):
@@ -100,16 +83,21 @@ class TestBaseSessionTimeout:
         session = BaseSession()
         
         # Create mock adapter and mount it
-        mock_adapter = MockAdapter()
+        mock_adapter = MagicMock(spec=BaseAdapter)
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.headers['Content-Type'] = 'application/json'
+        mock_response._content = b'{"key": "value"}'
+        mock_adapter.send.return_value = mock_response
         session.mount('http://', mock_adapter)
-        session.mount('https://', mock_adapter)
         
         # Make request without any timeout
         response = session.request('GET', 'http://example.com')
         
         # Verify no timeout was passed (should be None by default)
-        assert len(mock_adapter.captured_calls) == 1
-        assert mock_adapter.captured_calls[0]['timeout'] is None
+        mock_adapter.send.assert_called_once()
+        args, kwargs = mock_adapter.send.call_args
+        assert kwargs['timeout'] is None
         assert response.status_code == 200
 
     def test_timeout_tuple_support(self):
@@ -118,14 +106,19 @@ class TestBaseSessionTimeout:
         assert session.timeout == (3.0, 10.0)
         
         # Create mock adapter and mount it
-        mock_adapter = MockAdapter()
+        mock_adapter = MagicMock(spec=BaseAdapter)
+        mock_response = Response()
+        mock_response.status_code = 200
+        mock_response.headers['Content-Type'] = 'application/json'
+        mock_response._content = b'{"key": "value"}'
+        mock_adapter.send.return_value = mock_response
         session.mount('http://', mock_adapter)
-        session.mount('https://', mock_adapter)
         
         # Make request
         response = session.request('GET', 'http://example.com')
         
         # Verify tuple timeout was passed to send method
-        assert len(mock_adapter.captured_calls) == 1
-        assert mock_adapter.captured_calls[0]['timeout'] == (3.0, 10.0)
+        mock_adapter.send.assert_called_once()
+        args, kwargs = mock_adapter.send.call_args
+        assert kwargs['timeout'] == (3.0, 10.0)
         assert response.status_code == 200

--- a/tests/test_session_timeout.py
+++ b/tests/test_session_timeout.py
@@ -1,0 +1,133 @@
+import pytest
+import responses
+from requestspro.sessions import BaseSession
+
+
+class TestBaseSessionTimeout:
+    """Test timeout behavior in BaseSession."""
+
+    @responses.activate
+    def test_timeout_parameter(self):
+        responses.add(responses.GET, "http://example.com", json={"key": "value"})
+        
+        session = BaseSession(timeout=5.0)
+        assert session.timeout == 5.0
+
+    @responses.activate
+    def test_timeout_class_attribute(self):
+        class CustomSession(BaseSession):
+            TIMEOUT = 10.0
+        
+        session = CustomSession()
+        assert session.timeout == 10.0
+
+    @responses.activate
+    def test_timeout_parameter_overrides_class_attribute(self):
+        class CustomSession(BaseSession):
+            TIMEOUT = 10.0
+        
+        session = CustomSession(timeout=5.0)
+        assert session.timeout == 5.0
+
+    @responses.activate
+    def test_no_timeout_default(self):
+        session = BaseSession()
+        assert session.timeout is None
+
+    @responses.activate
+    def test_timeout_none_explicit(self):
+        session = BaseSession(timeout=None)
+        assert session.timeout is None
+
+    @responses.activate
+    def test_session_timeout_applied_to_request(self):
+        """Session timeout is used when no per-request timeout provided."""
+        responses.add(responses.GET, "http://example.com", json={"key": "value"})
+        
+        session = BaseSession(timeout=5.0)
+        
+        # Mock the parent request method to capture kwargs
+        original_request = BaseSession.__bases__[0].request
+        captured_kwargs = {}
+        
+        def mock_request(self, method, url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return original_request(self, method, url, **kwargs)
+        
+        BaseSession.__bases__[0].request = mock_request
+        
+        try:
+            session.request('GET', 'http://example.com')
+            assert captured_kwargs['timeout'] == 5.0
+        finally:
+            BaseSession.__bases__[0].request = original_request
+
+    @responses.activate
+    def test_per_request_timeout_overrides_session_timeout(self):
+        """Per-request timeout takes precedence over session timeout."""
+        responses.add(responses.GET, "http://example.com", json={"key": "value"})
+        
+        session = BaseSession(timeout=5.0)
+        
+        # Mock the parent request method to capture kwargs
+        original_request = BaseSession.__bases__[0].request
+        captured_kwargs = {}
+        
+        def mock_request(self, method, url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return original_request(self, method, url, **kwargs)
+        
+        BaseSession.__bases__[0].request = mock_request
+        
+        try:
+            session.request('GET', 'http://example.com', timeout=10.0)
+            assert captured_kwargs['timeout'] == 10.0
+        finally:
+            BaseSession.__bases__[0].request = original_request
+
+    @responses.activate
+    def test_no_session_timeout_no_per_request_timeout(self):
+        """No timeout applied when neither session nor per-request timeout provided."""
+        responses.add(responses.GET, "http://example.com", json={"key": "value"})
+        
+        session = BaseSession()
+        
+        # Mock the parent request method to capture kwargs
+        original_request = BaseSession.__bases__[0].request
+        captured_kwargs = {}
+        
+        def mock_request(self, method, url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return original_request(self, method, url, **kwargs)
+        
+        BaseSession.__bases__[0].request = mock_request
+        
+        try:
+            session.request('GET', 'http://example.com')
+            assert 'timeout' not in captured_kwargs
+        finally:
+            BaseSession.__bases__[0].request = original_request
+
+    @responses.activate
+    def test_timeout_tuple_support(self):
+        """Session timeout supports tuple format (connect, read)."""
+        responses.add(responses.GET, "http://example.com", json={"key": "value"})
+        
+        session = BaseSession(timeout=(3.0, 10.0))
+        assert session.timeout == (3.0, 10.0)
+        
+        # Mock the parent request method to capture kwargs
+        original_request = BaseSession.__bases__[0].request
+        captured_kwargs = {}
+        
+        def mock_request(self, method, url, **kwargs):
+            captured_kwargs.update(kwargs)
+            return original_request(self, method, url, **kwargs)
+        
+        BaseSession.__bases__[0].request = mock_request
+        
+        try:
+            session.request('GET', 'http://example.com')
+            assert captured_kwargs['timeout'] == (3.0, 10.0)
+        finally:
+            BaseSession.__bases__[0].request = original_request


### PR DESCRIPTION
Implements session-level timeout functionality as requested in issue #2.
- Add timeout parameter and TIMEOUT class attribute to BaseSession
- Session timeout applies when no per-request timeout is provided
- Per-request timeout takes precedence over session timeout
- Supports both single timeout values and (connect, read) tuples
- All session subclasses inherit timeout functionality automatically
- Add comprehensive tests covering timeout behavior