### PR TITLE
fix: skip JSON encoding on bodiless requests (GET)

### DIFF
--- a/docs/project/roadmap/index.md
+++ b/docs/project/roadmap/index.md
@@ -10,13 +10,12 @@ The roadmap describes meaningful progress, not every task. Taxonomy, codes, fold
 
 | Item | Status | Notes |
 |------|--------|-------|
-| (none) | — | Next pull: rebase + land PR #5 |
+| (none) | — | Next pull: land issue #4 audit stream fix |
 
 ## Planned Work
 
 | Item | Status | Notes |
 |------|--------|-------|
-| Maintenance: rebase + land PR #5 (`json=None` GET body) | Planned | Trivial quote-style conflict with the lint fix in `sessions.py` expected |
 | Maintenance: open + land PR from `claude/issue-4-20250915-2231` (audit stream placeholder) | Planned | Fix and tests already written; decision recorded in `decisions.md` |
 | Maintenance: land or fold `fix/handle-204-no-content` (D-008) | Planned | May merge into a future error-handling story instead |
 | Maintenance: delete obsolete branches (`claude/issue-2-*`, `add-claude-github-actions-*`) | Planned | Housekeeping |
@@ -31,6 +30,7 @@ The roadmap describes meaningful progress, not every task. Taxonomy, codes, fold
 
 | Item | Notes |
 |------|-------|
+| 2026-06-13 — Maintenance: skip JSON encoding on bodiless GET/DELETE requests (PR #5) | `sessions.py` early-return when no `data`/`json`; avoids a `null` body + JSON content-type on GETs that some CDNs reject |
 | 2026-06-12 — Maintenance: GitHub Actions pinned to Node 24 (checkout v6, setup-python v6, setup-uv v7) + publish.yml `python-version-file` fix | PR #6; CI green. setup-uv held at v7 to keep pin-by-major (see `decisions.md`) |
 | 2026-06-12 — Maintenance: lint debt paid (D-001) + `[build-system]` declared (D-002) | First Ariad delivery session; CI/release pipeline restored (green run on `main`) |
 | 2026-06-12 — Ariad adopted; deep survey of framework core + demo; CI root cause identified | See `docs/process/worklog.md` |

--- a/src/requestspro/sessions.py
+++ b/src/requestspro/sessions.py
@@ -139,6 +139,14 @@ class CustomJsonSession(BaseSession):
     def before_prepare_body(self, request):
         """Encode json using custom encoder before PrepareRequest.prepare_body is called."""
 
+        # When there is nothing to encode, skip entirely.
+        # request.data defaults to [] and request.json defaults to None on a new Request.
+        # Without this guard, json.dumps(None) produces "null" as a 4-byte body with
+        # Content-Type: application/json on every request — including GETs. Some CDNs
+        # (e.g. CloudFront) reject GET requests with a body.
+        if not request.data and request.json is None:
+            return
+
         # When Request has data but no json, there is nothing to encode.
         if request.data and request.json is None:
             return

--- a/tests/test_session_json.py
+++ b/tests/test_session_json.py
@@ -53,6 +53,29 @@ class SampleCustomJsonSession(CustomJsonSession, CustomResponseSession):
     RESPONSE_CLASS = ProResponse
 
 
+class TestCustomJsonSessionBodilessRequest:
+    """GET requests without json/data should not get a body or Content-Type header."""
+
+    def test_get_has_no_body(self, responses):
+        responses.add("GET", "https://h/data", json={"ok": True})
+        session = SampleCustomJsonSession()
+        response = session.get("https://h/data")
+        assert response.request.body is None
+
+    def test_get_has_no_content_type(self, responses):
+        responses.add("GET", "https://h/data", json={"ok": True})
+        session = SampleCustomJsonSession()
+        response = session.get("https://h/data")
+        assert "Content-Type" not in response.request.headers
+
+    def test_post_with_json_still_encodes(self, responses):
+        responses.add("POST", "https://h/data", json={"ok": True})
+        session = SampleCustomJsonSession()
+        response = session.post("https://h/data", json={"key": "val"})
+        assert response.request.body is not None
+        assert response.request.headers["Content-Type"] == "application/json"
+
+
 class TestCustomJsonSession:
     @pytest.fixture(autouse=True)
     def mocked_post(self, responses):


### PR DESCRIPTION
## Problem

`CustomJsonSession.before_prepare_body` encodes `json=None` as the string `"null"` (4 bytes) and sets `Content-Type: application/json` on every request, including GETs.

Some CDNs (e.g. CloudFront, used by Atlassian's API gateway) reject GET requests with a body, returning 403.

## Root cause

`Request()` defaults: `data=[]` (falsy) and `json=None`. The existing guard:

```python
if request.data and request.json is None:
    return
```

Only triggers when `data` is truthy. When both are falsy/None (the normal GET case), it falls through to `json.dumps(None)` → `"null"` → 4-byte body.

## Fix

Add an early return when there's nothing to encode:

```python
if not request.data and request.json is None:
    return
```

## Tests

3 new tests in `test_session_json.py`:
- GET request has no body
- GET request has no Content-Type header
- POST with json still encodes correctly (regression check)

All 44 tests pass.