### PR TITLE
fix: audit records <stream> placeholder for streamed bodies (#4)

### DIFF
--- a/docs/project/decisions.md
+++ b/docs/project/decisions.md
@@ -29,13 +29,13 @@ Consequences: Revisit setup-uv v8 (and SHA-pinning generally) if the repo adopts
 ### Audit replaces streamed bodies with a placeholder
 
 **Date:** 2025-09-15
-**Status:** Decided (implementation on branch `claude/issue-4-20250915-2231`, not yet merged)
+**Status:** Decided (landed 2026-06-13)
 
 Decision: When a request or response body is a stream (file-like/generator, or `stream=True`), the audit records a placeholder instead of materializing the body (issue #4; option 1 of the five discussed, chosen by the owner, TDD approach).
 
 Rationale: Reading the body inside the adapter either crashes (`AttributeError`/`UnicodeDecodeError` on file-like and binary bodies) or defeats streaming by loading everything into memory. Audit must never break or distort the request it observes.
 
-Consequences: Streamed bodies are not auditable by design; a richer strategy (sampling, metadata-only, content-type aware) stays on the radar.
+Consequences: Streamed bodies are not auditable by design; a richer strategy (sampling, metadata-only, content-type aware) stays on the radar. Detection: response streaming keys off the `stream` kwarg the audit adapter receives from `Session.send`; request streaming off a file-like or non-bytes-iterable body.
 
 ### Webhook verification belongs to the integration package
 

--- a/docs/project/roadmap/index.md
+++ b/docs/project/roadmap/index.md
@@ -4,20 +4,18 @@ The roadmap describes meaningful progress, not every task. Taxonomy, codes, fold
 
 ## Current Focus
 
-**Restore the delivery pipeline, then grow the framework.** CI was red on every push since 2025-07-31 because `main` carried auto-fixable lint debt; `lint` failed → `test` was skipped → `publish` could never run. Paid on 2026-06-12. Next: land the pending fixes (PR #5, issue #4 branch, 204 branch), then grow the framework toward the Navigator's vision — the same architecture in sync and async flavors, with the missing cross-cutting capabilities, legible enough that an agent can derive a new client from an API spec.
+**Restore the delivery pipeline, then grow the framework.** CI was red on every push since 2025-07-31 because `main` carried auto-fixable lint debt; `lint` failed → `test` was skipped → `publish` could never run. Paid on 2026-06-12, and the pending fixes have all landed (PR #5 bodiless-GET, #6 Node 24, #7 204, and the issue #4 audit stream fix). Next: grow the framework toward the Navigator's vision — the same architecture in sync and async flavors, with the missing cross-cutting capabilities, legible enough that an agent can derive a new client from an API spec.
 
 ## Active Work
 
 | Item | Status | Notes |
 |------|--------|-------|
-| (none) | — | Next pull: land issue #4 audit stream fix |
+| (none) | — | Next pull: framework growth — CV1 (error semantics) |
 
 ## Planned Work
 
 | Item | Status | Notes |
 |------|--------|-------|
-| Maintenance: open + land PR from `claude/issue-4-20250915-2231` (audit stream placeholder) | Planned | Fix and tests already written; decision recorded in `decisions.md` |
-| Maintenance: delete obsolete branches (`claude/issue-2-*`, `add-claude-github-actions-*`) | Planned | Housekeeping |
 | CV1 — Error semantics: API error taxonomy, `raise_for_status` hooks (incl. "HTTP 200 with error body"), transient/permanent classification, response-envelope hook | Planned | Framework ships no error hooks today; the demo hand-rolls `EduzzAPIError` + `ERROR_STATUSES` |
 | CV2 — Testing toolkit (`requestspro.testing`): `ProResponse` builders, recording fake session/adapter, given/when/then conventions | Planned | Test setup currently means manual `Response._content`/`headers`/`status_code` plumbing |
 | CV3 — Webhook verification toolkit: parametrizable HMAC verifier base (base string, headers, tolerance window, `compare_digest`, exception taxonomy, verify+parse atomicity) | Planned | The same skeleton fits any provider that HMAC-signs its webhooks; institutionalizes "verification lives in the integration package" |
@@ -29,6 +27,8 @@ The roadmap describes meaningful progress, not every task. Taxonomy, codes, fold
 
 | Item | Notes |
 |------|-------|
+| 2026-06-13 — Maintenance: audit records `<stream>` for streamed request/response bodies (issue #4) | Response streams detected via the `stream` kwarg; request streams via file-like/iterable body. See `decisions.md` |
+| 2026-06-13 — Maintenance: deleted merged/obsolete branches (`ci/node24-action-pins`, `add-claude-github-actions-*`, `claude/issue-2-*`) | Housekeeping; the timeout feature they carried already shipped via PR #3 |
 | 2026-06-13 — Maintenance: return `None` on 204 No Content in `Client.request` (D-008) | `client.py` returns `None` when the response has no body, instead of raising `JSONDecodeError` on 204/empty responses |
 | 2026-06-13 — Maintenance: skip JSON encoding on bodiless GET/DELETE requests (PR #5) | `sessions.py` early-return when no `data`/`json`; avoids a `null` body + JSON content-type on GETs that some CDNs reject |
 | 2026-06-12 — Maintenance: GitHub Actions pinned to Node 24 (checkout v6, setup-python v6, setup-uv v7) + publish.yml `python-version-file` fix | PR #6; CI green. setup-uv held at v7 to keep pin-by-major (see `decisions.md`) |

--- a/src/requestspro/audit.py
+++ b/src/requestspro/audit.py
@@ -59,6 +59,29 @@ class Audit(BaseAdapter):
     def close(self):
         return self.adapter.close()
 
+    def _safe_get_request_body(self, request):
+        """Safely extract request body, returning <stream> for stream-like objects."""
+        body = request.body
+        
+        if isinstance(body, str):
+            return body
+        
+        # Check if it's a stream-like object (has read method or is iterable but not bytes)
+        if hasattr(body, 'read') or (hasattr(body, '__iter__') and not isinstance(body, (bytes, str))):
+            return "<stream>"
+        
+        # Handle bytes and None as before
+        return (body or b"").decode()
+
+    def _safe_get_response_body(self, response):
+        """Safely extract response body, returning <stream> for streamed responses."""
+        # Check if response is being streamed
+        if hasattr(response, 'raw') and hasattr(response.raw, 'isclosed') and not response.raw.isclosed():
+            return "<stream>"
+        
+        # For normal responses, return text as before
+        return response.text
+
     def audit(self, response):
         """Turn a response and its request into a detailed log."""
         request = response.request
@@ -70,10 +93,10 @@ class Audit(BaseAdapter):
                 request_method=request.method,
                 request_url=request.url,
                 request_headers=dict(request.headers),
-                request_body=request.body if isinstance(request.body, str) else (request.body or b"").decode(),
+                request_body=self._safe_get_request_body(request),
                 response_status=response.status_code,
                 response_headers=dict(response.headers),
-                response_body=response.text,
+                response_body=self._safe_get_response_body(response),
             )
         )
 

--- a/src/requestspro/audit.py
+++ b/src/requestspro/audit.py
@@ -50,7 +50,9 @@ class Audit(BaseAdapter):
         return audit
 
     def send(self, request, **kwargs):
-        response = self.audit(self.adapter.send(request, **kwargs))
+        # stream=True means the caller will read the body lazily; reading it here to
+        # audit would consume the stream, so we record a placeholder instead.
+        response = self.audit(self.adapter.send(request, **kwargs), stream=kwargs.get("stream", False))
         # The response.connection is set as the wrapped adapter.
         # We must update it so any retries would pass through the audit.
         response.connection = self
@@ -60,29 +62,28 @@ class Audit(BaseAdapter):
         return self.adapter.close()
 
     def _safe_get_request_body(self, request):
-        """Safely extract request body, returning <stream> for stream-like objects."""
+        """Return a <stream> placeholder for stream-like request bodies; otherwise the body."""
         body = request.body
-        
+
         if isinstance(body, str):
             return body
-        
-        # Check if it's a stream-like object (has read method or is iterable but not bytes)
-        if hasattr(body, 'read') or (hasattr(body, '__iter__') and not isinstance(body, (bytes, str))):
+
+        # A file-like (has read) or non-bytes iterable (generator) body is a stream:
+        # reading it to audit would consume the upload, so record a placeholder.
+        if hasattr(body, "read") or (hasattr(body, "__iter__") and not isinstance(body, (bytes, str))):
             return "<stream>"
-        
-        # Handle bytes and None as before
+
+        # Bytes and None decode as before.
         return (body or b"").decode()
 
-    def _safe_get_response_body(self, response):
-        """Safely extract response body, returning <stream> for streamed responses."""
-        # Check if response is being streamed
-        if hasattr(response, 'raw') and hasattr(response.raw, 'isclosed') and not response.raw.isclosed():
+    def _safe_get_response_body(self, response, stream):
+        """Return a <stream> placeholder for streamed responses; otherwise the text body."""
+        if stream:
             return "<stream>"
-        
-        # For normal responses, return text as before
+
         return response.text
 
-    def audit(self, response):
+    def audit(self, response, *, stream=False):
         """Turn a response and its request into a detailed log."""
         request = response.request
 
@@ -96,7 +97,7 @@ class Audit(BaseAdapter):
                 request_body=self._safe_get_request_body(request),
                 response_status=response.status_code,
                 response_headers=dict(response.headers),
-                response_body=self._safe_get_response_body(response),
+                response_body=self._safe_get_response_body(response, stream),
             )
         )
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from io import BytesIO, StringIO
 
 from requests import HTTPError, Session
 from requests.adapters import HTTPAdapter, Response
@@ -149,3 +150,93 @@ class TestAuditFilter:
         for log in audit:
             assert log["request"]["headers"] == {}
             assert log["response"]["headers"] == {}
+
+
+class TestAuditStreams:
+    """Test cases for stream handling in audit logs."""
+
+    def test_request_with_file_like_object_should_show_stream_placeholder(self, responses):
+        """When request body is a file-like object, audit should show <stream> placeholder."""
+        responses.add("POST", "https://example.com/upload", status=200, json={"success": True})
+        
+        session = Session()
+        audit = Audit.for_session(session)
+        
+        # Create a file-like object
+        file_data = BytesIO(b"binary file content")
+        
+        session.post("https://example.com/upload", data=file_data)
+        
+        assert len(audit) == 1
+        event = audit[0]
+        assert event["request"]["body"] == "<stream>"
+
+    def test_request_with_generator_should_show_stream_placeholder(self, responses):
+        """When request body is a generator, audit should show <stream> placeholder."""
+        responses.add("POST", "https://example.com/upload", status=200, json={"success": True})
+        
+        session = Session()
+        audit = Audit.for_session(session)
+        
+        # Create a generator
+        def data_generator():
+            yield b"chunk1"
+            yield b"chunk2"
+        
+        session.post("https://example.com/upload", data=data_generator())
+        
+        assert len(audit) == 1
+        event = audit[0]
+        assert event["request"]["body"] == "<stream>"
+
+    def test_request_with_string_body_should_work_normally(self, responses):
+        """When request body is a string, audit should work as before."""
+        responses.add("POST", "https://example.com/data", status=200, json={"success": True})
+        
+        session = Session()
+        audit = Audit.for_session(session)
+        
+        session.post("https://example.com/data", data="normal string data")
+        
+        assert len(audit) == 1
+        event = audit[0]
+        assert event["request"]["body"] == "normal string data"
+
+    def test_request_with_bytes_body_should_work_normally(self, responses):
+        """When request body is bytes, audit should decode it as before."""
+        responses.add("POST", "https://example.com/data", status=200, json={"success": True})
+        
+        session = Session()
+        audit = Audit.for_session(session)
+        
+        session.post("https://example.com/data", data=b"normal bytes data")
+        
+        assert len(audit) == 1
+        event = audit[0]
+        assert event["request"]["body"] == "normal bytes data"
+
+    def test_response_with_stream_should_show_stream_placeholder(self, responses):
+        """When response is streamed, audit should show <stream> placeholder."""
+        responses.add("GET", "https://example.com/large-file", status=200, body="large file content")
+        
+        session = Session()
+        audit = Audit.for_session(session)
+        
+        response = session.get("https://example.com/large-file", stream=True)
+        
+        assert len(audit) == 1
+        event = audit[0]
+        assert event["response"]["body"] == "<stream>"
+
+    def test_normal_response_should_work_as_before(self, responses):
+        """When response is not streamed, audit should work as before."""
+        responses.add("GET", "https://example.com/data", status=200, json={"message": "hello"})
+        
+        session = Session()
+        audit = Audit.for_session(session)
+        
+        response = session.get("https://example.com/data")
+        
+        assert len(audit) == 1
+        event = audit[0]
+        assert '"message": "hello"' in event["response"]["body"]

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,8 +1,8 @@
 from datetime import datetime
-from io import BytesIO, StringIO
+from io import BytesIO
 
 from requests import HTTPError, Session
-from requests.adapters import HTTPAdapter, Response
+from requests.adapters import BaseAdapter, HTTPAdapter, Response
 
 from requestspro.audit import Audit, AuditDict
 from requestspro.auth import RecoverableAuth
@@ -152,21 +152,41 @@ class TestAuditFilter:
             assert log["response"]["headers"] == {}
 
 
+class CannedAdapter(BaseAdapter):
+    """Return a fixed response without reading request.body.
+
+    Unlike the `responses` mock, this preserves a file-like request body so the
+    audit can observe that it is a stream.
+    """
+
+    def send(self, request, **kwargs):
+        response = Response()
+        response.status_code = 200
+        response._content = b'{"success": true}'
+        response.request = request
+        response.url = request.url
+        return response
+
+    def close(self):
+        pass
+
+
 class TestAuditStreams:
     """Test cases for stream handling in audit logs."""
 
-    def test_request_with_file_like_object_should_show_stream_placeholder(self, responses):
-        """When request body is a file-like object, audit should show <stream> placeholder."""
-        responses.add("POST", "https://example.com/upload", status=200, json={"success": True})
-        
+    def test_request_with_file_like_object_should_show_stream_placeholder(self):
+        """A file-like request body is recorded as the <stream> placeholder.
+
+        Uses a canned adapter rather than `responses`, which would read the
+        BytesIO into a plain string before the audit sees it.
+        """
         session = Session()
-        audit = Audit.for_session(session)
-        
-        # Create a file-like object
+        audit = Audit(CannedAdapter())
+        session.mount("https://", audit)
+
         file_data = BytesIO(b"binary file content")
-        
         session.post("https://example.com/upload", data=file_data)
-        
+
         assert len(audit) == 1
         event = audit[0]
         assert event["request"]["body"] == "<stream>"
@@ -174,17 +194,17 @@ class TestAuditStreams:
     def test_request_with_generator_should_show_stream_placeholder(self, responses):
         """When request body is a generator, audit should show <stream> placeholder."""
         responses.add("POST", "https://example.com/upload", status=200, json={"success": True})
-        
+
         session = Session()
         audit = Audit.for_session(session)
-        
+
         # Create a generator
         def data_generator():
             yield b"chunk1"
             yield b"chunk2"
-        
+
         session.post("https://example.com/upload", data=data_generator())
-        
+
         assert len(audit) == 1
         event = audit[0]
         assert event["request"]["body"] == "<stream>"
@@ -192,12 +212,12 @@ class TestAuditStreams:
     def test_request_with_string_body_should_work_normally(self, responses):
         """When request body is a string, audit should work as before."""
         responses.add("POST", "https://example.com/data", status=200, json={"success": True})
-        
+
         session = Session()
         audit = Audit.for_session(session)
-        
+
         session.post("https://example.com/data", data="normal string data")
-        
+
         assert len(audit) == 1
         event = audit[0]
         assert event["request"]["body"] == "normal string data"
@@ -205,12 +225,12 @@ class TestAuditStreams:
     def test_request_with_bytes_body_should_work_normally(self, responses):
         """When request body is bytes, audit should decode it as before."""
         responses.add("POST", "https://example.com/data", status=200, json={"success": True})
-        
+
         session = Session()
         audit = Audit.for_session(session)
-        
+
         session.post("https://example.com/data", data=b"normal bytes data")
-        
+
         assert len(audit) == 1
         event = audit[0]
         assert event["request"]["body"] == "normal bytes data"
@@ -218,12 +238,12 @@ class TestAuditStreams:
     def test_response_with_stream_should_show_stream_placeholder(self, responses):
         """When response is streamed, audit should show <stream> placeholder."""
         responses.add("GET", "https://example.com/large-file", status=200, body="large file content")
-        
+
         session = Session()
         audit = Audit.for_session(session)
-        
-        response = session.get("https://example.com/large-file", stream=True)
-        
+
+        session.get("https://example.com/large-file", stream=True)
+
         assert len(audit) == 1
         event = audit[0]
         assert event["response"]["body"] == "<stream>"
@@ -231,12 +251,12 @@ class TestAuditStreams:
     def test_normal_response_should_work_as_before(self, responses):
         """When response is not streamed, audit should work as before."""
         responses.add("GET", "https://example.com/data", status=200, json={"message": "hello"})
-        
+
         session = Session()
         audit = Audit.for_session(session)
-        
-        response = session.get("https://example.com/data")
-        
+
+        session.get("https://example.com/data")
+
         assert len(audit) == 1
         event = audit[0]
         assert '"message": "hello"' in event["response"]["body"]


### PR DESCRIPTION
## Why

Closes #4. `Audit.audit()` materialized every request/response body (`request.body`/`response.text`). For streamed bodies (file-like/generator uploads, or `stream=True` downloads) that either crashes or defeats streaming by loading everything into memory. Audit must never break or distort the request it observes.

## What

Records a `<stream>` placeholder instead of materializing streamed bodies (decision recorded in `decisions.md`, option 1).

Builds on the original 2025 fix, **reworked** so it actually passes its tests on current `main`:
- **Response:** detect streaming via the `stream` kwarg `Audit.send` already receives from `Session.send` — the original `response.raw.isclosed()` sniff was `False` for ordinary responses and produced a false `<stream>`.
- **Request:** keep the file-like/iterable detection (correct for real adapters); the failing file-like test relied on `responses`, which reads the `BytesIO` into a string before audit sees it — replaced with a small canned adapter that leaves `request.body` intact.
- Conformed the 2025 code to current lint (`stream` made keyword-only for FBT002).

Folds Ariad docs: roadmap → Done (incl. completed branch cleanup), `decisions.md` → landed.

## Validation
- `pytest`: 50 passed locally (all 6 `TestAuditStreams` green); CI runs lint + py3.10–3.13.
- `pre-commit` (ruff 0.11.9) clean.
